### PR TITLE
ISSUE-2 Create minimal cookiecutter template

### DIFF
--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -1,0 +1,3 @@
+# {{ cookiecutter.project_name }}
+
+..add documentation..

--- a/{{ cookiecutter.project_slug }}/registry.json
+++ b/{{ cookiecutter.project_slug }}/registry.json
@@ -1,0 +1,11 @@
+{
+  "export_on_start": true,
+  "submodule": "compiled",
+  "target_functions": [
+    {
+      "module": "<Replace with module>",
+      "function_name": "<Replace with function name>",
+      "signature": "<Replace with type signature>"
+    }
+  ]
+}

--- a/{{ cookiecutter.project_slug }}/setup.py
+++ b/{{ cookiecutter.project_slug }}/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup, find_namespace_packages
+from numba_namespace_extension.registry import Registry
+
+setup(
+    name="{{ cookiecutter.project_slug }}",
+    version="{{ cookiecutter.version }}",
+    packages=find_namespace_packages(where="src"),
+    package_dir={
+        "": "src"
+    },
+    ext_modules=Registry.from_json("registry.json").ext_modules()
+)


### PR DESCRIPTION
This PR contains a minimal cookiecutter template to create numba namespace extensions.

Test by installing cookiecutter (i.e., `pip install cookiecutter`) and run:

```commandline
$ cookiecutter .
```

Closes #2 