### PR TITLE
ISSUE-5 Bash scripts: check style & types

### DIFF
--- a/check-style.sh
+++ b/check-style.sh
@@ -1,0 +1,3 @@
+pycodestyle setup.py --max-line-length 120
+pycodestyle src/numba_namespace_extension/ --max-line-length 120
+pycodestyle example/ --max-line-length 120

--- a/check-types.sh
+++ b/check-types.sh
@@ -1,0 +1,1 @@
+mypy src/numba_namespace_extension --ignore-missing-imports --install-types --non-interactive

--- a/requirements-develop.txt
+++ b/requirements-develop.txt
@@ -1,0 +1,5 @@
+cookiecutter==1.7.3
+pycodestyle==2.7.0
+mypy==0.910
+mypy-extensions==0.4.3
+scalene==1.3.12


### PR DESCRIPTION
This PR contains a couple of utility bash scripts to check python types & style.
* Closes #5 

Test by installing the development requirements:

```commandline
$ pip install -r requirements-develop.txt
```

And running the scripts:
* Stylecheck: `bash check-style.sh`
* Typecheck: `bash check-types.sh`
