### PR TITLE
ISSUE-15 PyPi Github Workflow

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -1,0 +1,40 @@
+name: PyPI Publish
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+jobs:
+  build:
+    # Check if PR was closed due to a merge.
+    if: github.event.pull_request.merged == true
+    # Create a job on Ubuntu 18.04
+    name: Build & Publish!
+    runs-on: ubuntu-18.04
+    steps:
+      # Copy github repo with submodules
+      - name: clone-repo
+        uses: actions/checkout@v1
+        with:
+          submodules: true
+      # Install python
+      - name: install-python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7.5'
+      # Install python dependencies
+      - name: install-twine
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install setuptools wheel twine
+      # Build and publish!
+      - name: build-and-publish
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python setup.py sdist
+          twine upload --skip-existing dist/*

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,0 +1,7 @@
+{
+  "project_name": "My Package Compiled",
+  "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}",
+  "project_namespace": "my_package",
+  "project_compiled_submodule": "compiled",
+  "version": "0.1.0"
+}


### PR DESCRIPTION
This PR creates a new github workflow to upload the libary into PyPi and adds a missing config file for the cookiecutter template.

Closes #15 