### PR TITLE
ISSUE-17 Fix PyPI Publishing Error

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -37,4 +37,4 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           python setup.py sdist
-          twine upload --skip-existing dist/*
+          twine upload --skip-existing --verbose dist/*

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,9 @@ with open("README.md", "r") as file:
 setup(
     name="numba_namespace_extension",
     version="0.1.0",
-    long_description=readme,
     description="Easily create compiled namespace Numba extensions.",
+    long_description_content_type="text/markdown",
+    long_description=readme,
     packages=find_namespace_packages(where="src"),
     package_dir={
         "": "src"


### PR DESCRIPTION
As noted in this [github issue](https://github.com/pypa/twine/issues/713), the fix is to simply define the long-description content type at the `setup` file.

Closes #17 